### PR TITLE
Nk/videobugfix

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -19,10 +19,13 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def destroy
-    tutorial = Tutorial.find(params[:id])
-    if tutorial.destroy
-      flash[:success] = "#{tutorial.title} tagged!"
-    end
+    # tutorial = Tutorial.find(params[:id])
+    # if tutorial.destroy
+    #   flash[:success] = "#{tutorial.title} tagged!"
+    # end
+    Tutorial.destroy(params[:id])
+    flash[:success] = "Tutorial Deleted."
+
     redirect_to admin_dashboard_path
   end
 

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -19,10 +19,6 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def destroy
-    # tutorial = Tutorial.find(params[:id])
-    # if tutorial.destroy
-    #   flash[:success] = "#{tutorial.title} tagged!"
-    # end
     Tutorial.destroy(params[:id])
     flash[:success] = "Tutorial Deleted."
 

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,5 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, ->  { order(position: :ASC) }
+  has_many :videos, ->  { order(position: :ASC) }, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :tutorials, only:[:show, :index]
+      resources :tutorials, only:[:show, :index, :destroy]
       resources :videos, only:[:show]
     end
   end

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -17,4 +17,23 @@ feature "An admin can delete a tutorial" do
 
     expect(page).to have_css('.admin-tutorial-card', count: 1)
   end
+
+  scenario "and its videos no longer exist" do
+    admin = create(:admin)
+    tutorial = create(:tutorial)
+
+    video = create(:video, tutorial: tutorial )
+    # require "pry"; binding.pry
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit "/admin/dashboard"
+
+    expect(page).to have_css('.admin-tutorial-card', count: 1)
+
+    within(first('.admin-tutorial-card')) do
+      click_link 'Delete'
+    end
+
+    expect { Video.find(video.id) }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
 end

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -23,7 +23,7 @@ feature "An admin can delete a tutorial" do
     tutorial = create(:tutorial)
 
     video = create(:video, tutorial: tutorial )
-    # require "pry"; binding.pry
+
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit "/admin/dashboard"

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -16,6 +16,8 @@ feature "An admin can delete a tutorial" do
     end
 
     expect(page).to have_css('.admin-tutorial-card', count: 1)
+    expect(current_path).to eq("/admin/dashboard")
+    expect(page).to have_content("Tutorial Deleted.")
   end
 
   scenario "and its videos no longer exist" do


### PR DESCRIPTION
Added dependent destroy for videos when a tutorial has been destroyed. Added more dynamic testing for deleting a tutorial. 

Coverage report generated for RSpec to /Users/nathankeller/turing/3module/projects/brownfield-of-dreams/coverage. 244 / 301 LOC (81.06%) covered
